### PR TITLE
KF5 v5.9.0

### DIFF
--- a/kf5-attica.rb
+++ b/kf5-attica.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Attica < Formula
-  url "http://download.kde.org/stable/frameworks/5.8/attica-5.8.0.tar.xz"
-  sha1 "aea15d99d1d48969b8e53091295d18802231c6cc"
+  url "http://download.kde.org/stable/frameworks/5.9/attica-5.9.0.tar.xz"
+  sha1 "f4f788d871da310d4b659ac13d50c79e33791cc7"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/attica.git'

--- a/kf5-extra-cmake-modules.rb
+++ b/kf5-extra-cmake-modules.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5ExtraCmakeModules < Formula
-  url "http://download.kde.org/stable/frameworks/5.8/extra-cmake-modules-1.8.0.tar.xz"
-  sha1 "34a57abe092dce75b7f25808e686fb9175ceafc3"
+  url "http://download.kde.org/stable/frameworks/5.9/extra-cmake-modules-5.9.0.tar.xz"
+  sha1 "bbfc5d9ec13e88454f6da8c527d9bb83453bcb85"
   homepage "http://www.kde.org/"
 
   keg_only "Only required for building KDE frameworks"

--- a/kf5-frameworkintegration.rb
+++ b/kf5-frameworkintegration.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Frameworkintegration < Formula
-  url "http://download.kde.org/stable/frameworks/5.8/frameworkintegration-5.8.0.tar.xz"
-  sha1 "5ee49f3b9cffb44b4557234f000af69d7e4c000e"
+  url "http://download.kde.org/stable/frameworks/5.9/frameworkintegration-5.9.0.tar.xz"
+  sha1 "90f74c4addb6b9abe99be61760800ad9046c8129"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/frameworkintegration.git'

--- a/kf5-kactivities.rb
+++ b/kf5-kactivities.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kactivities < Formula
-  url "http://download.kde.org/stable/frameworks/5.8/kactivities-5.8.0.tar.xz"
-  sha1 "b78e40acd4dca570c11dea69d3a4f334f59d078c"
+  url "http://download.kde.org/stable/frameworks/5.9/kactivities-5.9.0.tar.xz"
+  sha1 "4356688e2c64101df5c340b59ab211e484f745a2"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kactivities.git'

--- a/kf5-kapidox.rb
+++ b/kf5-kapidox.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kapidox < Formula
-  url "http://download.kde.org/stable/frameworks/5.8/kapidox-5.8.0.tar.xz"
-  sha1 "743d832c06eb2774f023e2d8db070b3e491929a1"
+  url "http://download.kde.org/stable/frameworks/5.9/kapidox-5.9.0.tar.xz"
+  sha1 "66c1bc8a19afcc43aa4cbb8d48002fa466864e73"
   homepage "http://www.kde.org/"
 
   depends_on "cmake" => :build

--- a/kf5-karchive.rb
+++ b/kf5-karchive.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Karchive < Formula
-  url "http://download.kde.org/stable/frameworks/5.8/karchive-5.8.0.tar.xz"
-  sha1 "e31c948b021e2da3597edf6d650691264d8ad177"
+  url "http://download.kde.org/stable/frameworks/5.9/karchive-5.9.0.tar.xz"
+  sha1 "79d5c57655a93cc49d904ad9ae715205b6a220e1"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/karchive.git'

--- a/kf5-kate.rb
+++ b/kf5-kate.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kate < Formula
-  url "http://download.kde.org/stable/applications/14.12.2/src/kate-14.12.2.tar.xz"
-  sha1 "bc3a5b1213fbe96756261daadf9ff8f94e74fd9c"
+  url "http://download.kde.org/stable/applications/14.12.3/src/kate-14.12.3.tar.xz"
+  sha1 "57a34ad4dfb8e1a8c8f76244cf571cb1ce8f5c28"
   homepage "http://www.kde.org/"
 
   head "git://anongit.kde.org/kate.git"

--- a/kf5-kauth.rb
+++ b/kf5-kauth.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kauth < Formula
-  url "http://download.kde.org/stable/frameworks/5.8/kauth-5.8.0.tar.xz"
-  sha1 "2723d951c1be06f8483c03933599b02d6be48f4e"
+  url "http://download.kde.org/stable/frameworks/5.9/kauth-5.9.0.tar.xz"
+  sha1 "15f03e20dad66adaca9a668701ae4eb303ecf376"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kauth.git'

--- a/kf5-kbookmarks.rb
+++ b/kf5-kbookmarks.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kbookmarks < Formula
-  url "http://download.kde.org/stable/frameworks/5.8/kbookmarks-5.8.0.tar.xz"
-  sha1 "b893da19487320f1a5649ac2d671b366393ea3b0"
+  url "http://download.kde.org/stable/frameworks/5.9/kbookmarks-5.9.0.tar.xz"
+  sha1 "76550b3bc301950cec61c371cb885ab08e4a7668"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kbookmarks.git'

--- a/kf5-kcmutils.rb
+++ b/kf5-kcmutils.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kcmutils < Formula
-  url "http://download.kde.org/stable/frameworks/5.8/kcmutils-5.8.0.tar.xz"
-  sha1 "b66afcdb018c539174d5fa8f748e639c6b55c46a"
+  url "http://download.kde.org/stable/frameworks/5.9/kcmutils-5.9.0.tar.xz"
+  sha1 "1750238f31d4361c63c366129f48aff8754be4f5"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kcmutils.git'

--- a/kf5-kcodecs.rb
+++ b/kf5-kcodecs.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kcodecs < Formula
-  url "http://download.kde.org/stable/frameworks/5.8/kcodecs-5.8.0.tar.xz"
-  sha1 "95692e6693fe9ffde6350be47741620429d07488"
+  url "http://download.kde.org/stable/frameworks/5.9/kcodecs-5.9.0.tar.xz"
+  sha1 "5ffecde580419cc1c7e018a303f1bafb6d4d4c4b"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kcodecs.git'

--- a/kf5-kcompletion.rb
+++ b/kf5-kcompletion.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kcompletion < Formula
-  url "http://download.kde.org/stable/frameworks/5.8/kcompletion-5.8.0.tar.xz"
-  sha1 "452f017bdf7262d98b1660cb4be08e8ca5f76d96"
+  url "http://download.kde.org/stable/frameworks/5.9/kcompletion-5.9.0.tar.xz"
+  sha1 "5595077392ccf2a6f97797cfeaa19c78f5b291ba"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kcompletion.git'

--- a/kf5-kconfig.rb
+++ b/kf5-kconfig.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kconfig < Formula
-  url "http://download.kde.org/stable/frameworks/5.8/kconfig-5.8.0.tar.xz"
-  sha1 "f1e78e1b29a6d255c5cb67172c8c23ac585b6df3"
+  url "http://download.kde.org/stable/frameworks/5.9/kconfig-5.9.0.tar.xz"
+  sha1 "0e225b49cbe34130ba8f8b419d379e39ac27ffe9"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kconfig.git'

--- a/kf5-kconfigwidgets.rb
+++ b/kf5-kconfigwidgets.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kconfigwidgets < Formula
-  url "http://download.kde.org/stable/frameworks/5.8/kconfigwidgets-5.8.0.tar.xz"
-  sha1 "4632522230ef115ba4871c37cf2e19241dcf979b"
+  url "http://download.kde.org/stable/frameworks/5.9/kconfigwidgets-5.9.0.tar.xz"
+  sha1 "e4d1da3244f3a1c578d25805afdaf07d8acd2ab5"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kconfigwidgets.git'

--- a/kf5-kcoreaddons.rb
+++ b/kf5-kcoreaddons.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kcoreaddons < Formula
-  url "http://download.kde.org/stable/frameworks/5.8/kcoreaddons-5.8.0.tar.xz"
-  sha1 "41aa49d1c6580e5d00818270e0272e2478d6e3b2"
+  url "http://download.kde.org/stable/frameworks/5.9/kcoreaddons-5.9.0.tar.xz"
+  sha1 "23b86058ad4fcb13571f330fedb88c352525f8ae"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kcoreaddons.git'

--- a/kf5-kcrash.rb
+++ b/kf5-kcrash.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kcrash < Formula
-  url "http://download.kde.org/stable/frameworks/5.8/kcrash-5.8.0.tar.xz"
-  sha1 "6a2da848ea154d10c5a46960797d54d97762054a"
+  url "http://download.kde.org/stable/frameworks/5.9/kcrash-5.9.0.tar.xz"
+  sha1 "06cfff2bcd246d9ccc7afbc6abf40a465277d9b2"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kcrash.git'

--- a/kf5-kdbusaddons.rb
+++ b/kf5-kdbusaddons.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kdbusaddons < Formula
-  url "http://download.kde.org/stable/frameworks/5.8/kdbusaddons-5.8.0.tar.xz"
-  sha1 "c08022914d159e85d875bc6d9e292dacec8a6ac6"
+  url "http://download.kde.org/stable/frameworks/5.9/kdbusaddons-5.9.0.tar.xz"
+  sha1 "3c1364b9f9c8bc122e8683591a748256bbeda688"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kdbusaddons.git'

--- a/kf5-kdeclarative.rb
+++ b/kf5-kdeclarative.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kdeclarative < Formula
-  url "http://download.kde.org/stable/frameworks/5.8/kdeclarative-5.8.0.tar.xz"
-  sha1 "37ff6e3b96784c91a5af1fdf56088bc7c8503262"
+  url "http://download.kde.org/stable/frameworks/5.9/kdeclarative-5.9.0.tar.xz"
+  sha1 "b8a939f7c1b786c95bb99cee941812e7253bb999"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kdeclarative.git'

--- a/kf5-kded.rb
+++ b/kf5-kded.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kded < Formula
-  url "http://download.kde.org/stable/frameworks/5.8/kded-5.8.0.tar.xz"
-  sha1 "07b2e35291320875300ee844f708b3b256302ab7"
+  url "http://download.kde.org/stable/frameworks/5.9/kded-5.9.0.tar.xz"
+  sha1 "37090e503b0e3af77ca7c83ca6b6e7ec3c1fa3f2"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kded.git'

--- a/kf5-kdelibs4support.rb
+++ b/kf5-kdelibs4support.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kdelibs4support < Formula
-  url "http://download.kde.org/stable/frameworks/5.8/portingAids/kdelibs4support-5.8.0.tar.xz"
-  sha1 "e9962e1a803d7dc46799e7fc3cc95505c277132f"
+  url "http://download.kde.org/stable/frameworks/5.9/portingAids/kdelibs4support-5.9.0.tar.xz"
+  sha1 "c08531e8e0458c1bdca5101b714e17aa9036e375"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kdelibs4support.git'

--- a/kf5-kdesignerplugin.rb
+++ b/kf5-kdesignerplugin.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kdesignerplugin < Formula
-  url "http://download.kde.org/stable/frameworks/5.8/kdesignerplugin-5.8.0.tar.xz"
-  sha1 "00a9b826d8d3a7eb39bb018a2783cb32e569fa57"
+  url "http://download.kde.org/stable/frameworks/5.9/kdesignerplugin-5.9.0.tar.xz"
+  sha1 "b007659e974560faeffd8feff54e3565009af602"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kdesignerplugin.git'

--- a/kf5-kdesu.rb
+++ b/kf5-kdesu.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kdesu < Formula
-  url "http://download.kde.org/stable/frameworks/5.8/kdesu-5.8.0.tar.xz"
-  sha1 "42c74327f5c9f7adc981120e1521816396853ddc"
+  url "http://download.kde.org/stable/frameworks/5.9/kdesu-5.9.0.tar.xz"
+  sha1 "e05ccdc297a3d4a2071664fe92433887a2843650"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kdesu.git'

--- a/kf5-kdewebkit.rb
+++ b/kf5-kdewebkit.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kdewebkit < Formula
-  url "http://download.kde.org/stable/frameworks/5.8/kdewebkit-5.8.0.tar.xz"
-  sha1 "c1e5bf22f6081ab5833836868a0b09a0ae335074"
+  url "http://download.kde.org/stable/frameworks/5.9/kdewebkit-5.9.0.tar.xz"
+  sha1 "283fc857ae8d580643ce74177fbcf4c008c5a55f"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/attica.git'

--- a/kf5-kdnssd.rb
+++ b/kf5-kdnssd.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kdnssd < Formula
-  url "http://download.kde.org/stable/frameworks/5.8/kdnssd-5.8.0.tar.xz"
-  sha1 "c3a73ed275d8dd4835a51b6653d1520d43dfcaa7"
+  url "http://download.kde.org/stable/frameworks/5.9/kdnssd-5.9.0.tar.xz"
+  sha1 "6e86c7b64f5efe9e2b804534ee7f45e4efbce229"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/attica.git'

--- a/kf5-kdoctools.rb
+++ b/kf5-kdoctools.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kdoctools < Formula
-  url "http://download.kde.org/stable/frameworks/5.8/kdoctools-5.8.0.tar.xz"
-  sha1 "8ea833b450df2cf25dcdf36effc8e15b5b3fab11"
+  url "http://download.kde.org/stable/frameworks/5.9/kdoctools-5.9.0.tar.xz"
+  sha1 "46a9be63ff34ce10a29fd74db6b39ad76d846838"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kdoctools.git'

--- a/kf5-kemoticons.rb
+++ b/kf5-kemoticons.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kemoticons < Formula
-  url "http://download.kde.org/stable/frameworks/5.8/kemoticons-5.8.0.tar.xz"
-  sha1 "935f9f76b69ba1a468db0b30760089502d180a01"
+  url "http://download.kde.org/stable/frameworks/5.9/kemoticons-5.9.0.tar.xz"
+  sha1 "d73a5fda5ab53721646a9468a61cb5f4ee47be53"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kemoticons.git'

--- a/kf5-kglobalaccel.rb
+++ b/kf5-kglobalaccel.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kglobalaccel < Formula
-  url "http://download.kde.org/stable/frameworks/5.8/kglobalaccel-5.8.0.tar.xz"
-  sha1 "95d285e1d7f36f006c082af0a0a8239019876670"
+  url "http://download.kde.org/stable/frameworks/5.9/kglobalaccel-5.9.0.tar.xz"
+  sha1 "b406c0c3cf220d77d491d4482333799f7a4c365a"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kglobalaccel.git'

--- a/kf5-kguiaddons.rb
+++ b/kf5-kguiaddons.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kguiaddons < Formula
-  url "http://download.kde.org/stable/frameworks/5.8/kguiaddons-5.8.0.tar.xz"
-  sha1 "6d7699ed6d70dc0360c7a400e5a92b444a39162f"
+  url "http://download.kde.org/stable/frameworks/5.9/kguiaddons-5.9.0.tar.xz"
+  sha1 "9ad5c89974fef1ccec9af2833c3b047705307a2a"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kguiaddons.git'

--- a/kf5-ki18n.rb
+++ b/kf5-ki18n.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Ki18n < Formula
-  url "http://download.kde.org/stable/frameworks/5.8/ki18n-5.8.0.tar.xz"
-  sha1 "5443bc6f606dd162c246925ec3f04867f9533672"
+  url "http://download.kde.org/stable/frameworks/5.9/ki18n-5.9.0.tar.xz"
+  sha1 "e0147606b8eb0d2f6ae484e39d637a04061d8cde"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/ki18n.git'

--- a/kf5-kiconthemes.rb
+++ b/kf5-kiconthemes.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kiconthemes < Formula
-  url "http://download.kde.org/stable/frameworks/5.8/kiconthemes-5.8.0.tar.xz"
-  sha1 "44d720c39294ce6a12da73dd4acc0303fb420184"
+  url "http://download.kde.org/stable/frameworks/5.9/kiconthemes-5.9.0.tar.xz"
+  sha1 "0012432033270b5f8c74a1d9c1caed2813ca64ea"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kiconthemes.git'

--- a/kf5-kidletime.rb
+++ b/kf5-kidletime.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kidletime < Formula
-  url "http://download.kde.org/stable/frameworks/5.8/kidletime-5.8.0.tar.xz"
-  sha1 "5b6132d778a9e265cafc8e402a368157a4ba7476"
+  url "http://download.kde.org/stable/frameworks/5.9/kidletime-5.9.0.tar.xz"
+  sha1 "41393450f4d59b445aa1ab37e27b6e74e725fc9d"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kidletime.git'

--- a/kf5-kimageformats.rb
+++ b/kf5-kimageformats.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kimageformats < Formula
-  url "http://download.kde.org/stable/frameworks/5.8/kimageformats-5.8.0.tar.xz"
-  sha1 "aa8a16046e106b5eacbb307fc7b11f3b742c0b86"
+  url "http://download.kde.org/stable/frameworks/5.9/kimageformats-5.9.0.tar.xz"
+  sha1 "6ed7f11a3ab5d55d89caea5fff2e2825c61b1bf8"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kimageformats.git'

--- a/kf5-kinit.rb
+++ b/kf5-kinit.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kinit < Formula
-  url "http://download.kde.org/stable/frameworks/5.8/kinit-5.8.0.tar.xz"
-  sha1 "e15f8f1b8e37e471abf00d36104922def3903c99"
+  url "http://download.kde.org/stable/frameworks/5.9/kinit-5.9.0.tar.xz"
+  sha1 "da9e42074b3a9cd28d784a7247ce81c411a673d7"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kinit.git'

--- a/kf5-kio.rb
+++ b/kf5-kio.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kio < Formula
-  url "http://download.kde.org/stable/frameworks/5.8/kio-5.8.0.tar.xz"
-  sha1 "422122b6aa715472aad5ce86938940a241e1fbd0"
+  url "http://download.kde.org/stable/frameworks/5.9/kio-5.9.0.tar.xz"
+  sha1 "1dac8211c1a98bc2285ef2495f1362e62dd44c48"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kio.git'

--- a/kf5-kitemmodels.rb
+++ b/kf5-kitemmodels.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kitemmodels < Formula
-  url "http://download.kde.org/stable/frameworks/5.8/kitemmodels-5.8.0.tar.xz"
-  sha1 "e65692e84ee86a369888403431e2d489add858e6"
+  url "http://download.kde.org/stable/frameworks/5.9/kitemmodels-5.9.0.tar.xz"
+  sha1 "4d69e3c6e5328a0bb595c54f382a729ee046d056"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kitemmodels.git'

--- a/kf5-kitemviews.rb
+++ b/kf5-kitemviews.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kitemviews < Formula
-  url "http://download.kde.org/stable/frameworks/5.8/kitemviews-5.8.0.tar.xz"
-  sha1 "483af2ff63a8de102522520e791240c6e77f9056"
+  url "http://download.kde.org/stable/frameworks/5.9/kitemviews-5.9.0.tar.xz"
+  sha1 "9fb3ea66eeb06c9da5974dfe3f108874d3ea416f"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kitemviews.git'

--- a/kf5-kjobwidgets.rb
+++ b/kf5-kjobwidgets.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kjobwidgets < Formula
-  url "http://download.kde.org/stable/frameworks/5.8/kjobwidgets-5.8.0.tar.xz"
-  sha1 "8b97c8cf2a01d6ab387c77b5e14c52d18b443ff1"
+  url "http://download.kde.org/stable/frameworks/5.9/kjobwidgets-5.9.0.tar.xz"
+  sha1 "6345a8709f967b953b61901699b05969139e4461"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kjobwidgets.git'

--- a/kf5-kjs.rb
+++ b/kf5-kjs.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kjs < Formula
-  url "http://download.kde.org/stable/frameworks/5.8/portingAids/kjs-5.8.0.tar.xz"
-  sha1 "b452c7e18d7969df6e61935b9c5c95a51d4ecc4e"
+  url "http://download.kde.org/stable/frameworks/5.9/portingAids/kjs-5.9.0.tar.xz"
+  sha1 "594f5fb9825fe06f4fc80737c29eefd35f1d8040"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kjs.git'

--- a/kf5-kjsembed.rb
+++ b/kf5-kjsembed.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kjsembed < Formula
-  url "http://download.kde.org/stable/frameworks/5.8/portingAids/kjsembed-5.8.0.tar.xz"
-  sha1 "eb5b72edb4348d12b94c08e7d60c44604ae49780"
+  url "http://download.kde.org/stable/frameworks/5.9/portingAids/kjsembed-5.9.0.tar.xz"
+  sha1 "3e3dd035eac4f01a2857951b2e6c03fa99db09bb"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/attica.git'

--- a/kf5-kmediaplayer.rb
+++ b/kf5-kmediaplayer.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kmediaplayer < Formula
-  url "http://download.kde.org/stable/frameworks/5.8/portingAids/kmediaplayer-5.8.0.tar.xz"
-  sha1 "0a9e970461f263761652063bc21834cb4467e082"
+  url "http://download.kde.org/stable/frameworks/5.9/portingAids/kmediaplayer-5.9.0.tar.xz"
+  sha1 "ff400bda60ffff2ffe0e3a9c98c99581dde72ccc"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/attica.git'

--- a/kf5-knewstuff.rb
+++ b/kf5-knewstuff.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Knewstuff < Formula
-  url "http://download.kde.org/stable/frameworks/5.8/knewstuff-5.8.0.tar.xz"
-  sha1 "1c39d9304ac2c7b467c81374253543b73e9f1b2f"
+  url "http://download.kde.org/stable/frameworks/5.9/knewstuff-5.9.0.tar.xz"
+  sha1 "98df76e39914330b4a1dfee8cf934a4447133695"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/knewstuff.git'

--- a/kf5-knotifications.rb
+++ b/kf5-knotifications.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Knotifications < Formula
-  url "http://download.kde.org/stable/frameworks/5.8/knotifications-5.8.0.tar.xz"
-  sha1 "d7c784173c96fb598e61046cf6f818a8d2dd7d5d"
+  url "http://download.kde.org/stable/frameworks/5.9/knotifications-5.9.0.tar.xz"
+  sha1 "4c541936a00dc039e210a191e780bcd8a9920579"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/knotifications.git'

--- a/kf5-knotifyconfig.rb
+++ b/kf5-knotifyconfig.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Knotifyconfig < Formula
-  url "http://download.kde.org/stable/frameworks/5.8/knotifyconfig-5.8.0.tar.xz"
-  sha1 "2b874c9adf980ed9e547918ea5779ac0310b4e52"
+  url "http://download.kde.org/stable/frameworks/5.9/knotifyconfig-5.9.0.tar.xz"
+  sha1 "922e53d6453a9c0d16175c576693df8521facd37"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/knotifyconfig.git'

--- a/kf5-kpackage.rb
+++ b/kf5-kpackage.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kpackage < Formula
-  url "http://download.kde.org/stable/frameworks/5.8/kpackage-5.8.0.tar.xz"
-  sha1 "8882c10020f8763f4d40707da377bd24be9b24ef"
+  url "http://download.kde.org/stable/frameworks/5.9/kpackage-5.9.0.tar.xz"
+  sha1 "8e501753b318fe2fb3741cc2fa462dfab152d005"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kpackage.git'

--- a/kf5-kparts.rb
+++ b/kf5-kparts.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kparts < Formula
-  url "http://download.kde.org/stable/frameworks/5.8/kparts-5.8.0.tar.xz"
-  sha1 "33d1529176fc5957c77128dc889b0963eb9698f2"
+  url "http://download.kde.org/stable/frameworks/5.9/kparts-5.9.0.tar.xz"
+  sha1 "6cfa0ef61145a10fc970c61631d87ef7a18400b1"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kparts.git'

--- a/kf5-kplotting.rb
+++ b/kf5-kplotting.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kplotting < Formula
-  url "http://download.kde.org/stable/frameworks/5.8/kplotting-5.8.0.tar.xz"
-  sha1 "beddec71add49c48e76a3edd6e5574c8a61499a1"
+  url "http://download.kde.org/stable/frameworks/5.9/kplotting-5.9.0.tar.xz"
+  sha1 "f3e6ac040aeb35cc70c17b3d70b106c0e24c6fd2"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kplotting.git'

--- a/kf5-kpty.rb
+++ b/kf5-kpty.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kpty < Formula
-  url "http://download.kde.org/stable/frameworks/5.8/kpty-5.8.0.tar.xz"
-  sha1 "a0e7618c45cf6bfda002125cf1596efc2ba69812"
+  url "http://download.kde.org/stable/frameworks/5.9/kpty-5.9.0.tar.xz"
+  sha1 "b140cd4ae17e9c2c1cc69165f48579d0124970a3"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kpty.git'

--- a/kf5-kross.rb
+++ b/kf5-kross.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kross < Formula
-  url "http://download.kde.org/stable/frameworks/5.8/portingAids/kross-5.8.0.tar.xz"
-  sha1 "2b2ca516c7a884b9706a6d681aae6b31f5b74347"
+  url "http://download.kde.org/stable/frameworks/5.9/portingAids/kross-5.9.0.tar.xz"
+  sha1 "8d7c97ab4c4ee14b4c5be4b84d1021ca1c872744"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kross.git'

--- a/kf5-kservice.rb
+++ b/kf5-kservice.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kservice < Formula
-  url "http://download.kde.org/stable/frameworks/5.8/kservice-5.8.0.tar.xz"
-  sha1 "30c5d582efb0c21447c5b018df6af54a1c764f7a"
+  url "http://download.kde.org/stable/frameworks/5.9/kservice-5.9.0.tar.xz"
+  sha1 "19790a000a6bc783a51c4c24af6376c74ea31af0"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kservice.git'

--- a/kf5-ktexteditor.rb
+++ b/kf5-ktexteditor.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Ktexteditor < Formula
-  url "http://download.kde.org/stable/frameworks/5.8/ktexteditor-5.8.0.tar.xz"
-  sha1 "14e212af889efdbe2f2d0a099d9fad9fdaad44e9"
+  url "http://download.kde.org/stable/frameworks/5.9/ktexteditor-5.9.0.tar.xz"
+  sha1 "1a87fb8222952362bcee31eb86db64798267cad2"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/ktexteditor.git'

--- a/kf5-ktextwidgets.rb
+++ b/kf5-ktextwidgets.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Ktextwidgets < Formula
-  url "http://download.kde.org/stable/frameworks/5.8/ktextwidgets-5.8.0.tar.xz"
-  sha1 "e05b62d147cea1a40a2d624b41fdc4d8466d79e1"
+  url "http://download.kde.org/stable/frameworks/5.9/ktextwidgets-5.9.0.tar.xz"
+  sha1 "c5c7f336d4f9d658fc70813fa241ebf17500c483"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/ktextwidgets.git'

--- a/kf5-kunitconversion.rb
+++ b/kf5-kunitconversion.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kunitconversion < Formula
-  url "http://download.kde.org/stable/frameworks/5.8/kunitconversion-5.8.0.tar.xz"
-  sha1 "9eb97efe7f66a4b3555a83bbff4a625a58e47619"
+  url "http://download.kde.org/stable/frameworks/5.9/kunitconversion-5.9.0.tar.xz"
+  sha1 "1fbb07d5832301708ec46715a00bcdb591996e8b"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kunitconversion.git'

--- a/kf5-kwallet.rb
+++ b/kf5-kwallet.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kwallet < Formula
-  url "http://download.kde.org/stable/frameworks/5.8/kwallet-5.8.0.tar.xz"
-  sha1 "0e341586d72f98e04a38e8ddf7991247324e4884"
+  url "http://download.kde.org/stable/frameworks/5.9/kwallet-5.9.0.tar.xz"
+  sha1 "b0b8edd94ab3f321e3c47199740a083472028aff"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kwallet.git'

--- a/kf5-kwidgetsaddons.rb
+++ b/kf5-kwidgetsaddons.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kwidgetsaddons < Formula
-  url "http://download.kde.org/stable/frameworks/5.8/kwidgetsaddons-5.8.0.tar.xz"
-  sha1 "ef4b3987accfa7ff933ca577a846e27f8d1d8a4a"
+  url "http://download.kde.org/stable/frameworks/5.9/kwidgetsaddons-5.9.0.tar.xz"
+  sha1 "72e77572a645b137f47f845c3b87f131056fab3b"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kwidgetsaddons.git'

--- a/kf5-kwindowsystem.rb
+++ b/kf5-kwindowsystem.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kwindowsystem < Formula
-  url "http://download.kde.org/stable/frameworks/5.8/kwindowsystem-5.8.0.tar.xz"
-  sha1 "d49b39ed177f83bb2f40587a6897f899193e55c4"
+  url "http://download.kde.org/stable/frameworks/5.9/kwindowsystem-5.9.0.tar.xz"
+  sha1 "1dfe65a9f4c0c3e99342a8b085d0b60bf4fef296"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kwindowsystem.git'

--- a/kf5-kxmlgui.rb
+++ b/kf5-kxmlgui.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kxmlgui < Formula
-  url "http://download.kde.org/stable/frameworks/5.8/kxmlgui-5.8.0.tar.xz"
-  sha1 "a4368e07119e498cba24c4a999b35443982490c9"
+  url "http://download.kde.org/stable/frameworks/5.9/kxmlgui-5.9.0.tar.xz"
+  sha1 "25e7b6d436335f957020750cc56e79b5579f4fdb"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kxmlgui.git'

--- a/kf5-solid.rb
+++ b/kf5-solid.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Solid < Formula
-  url "http://download.kde.org/stable/frameworks/5.8/solid-5.8.0.tar.xz"
-  sha1 "cdc064fe1044e24f701454ec2b01689e69fc43d5"
+  url "http://download.kde.org/stable/frameworks/5.9/solid-5.9.0.tar.xz"
+  sha1 "bcd5e23912af1e6b084b0dd2f0f2a37529603754"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/solid.git'

--- a/kf5-sonnet.rb
+++ b/kf5-sonnet.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Sonnet < Formula
-  url "http://download.kde.org/stable/frameworks/5.8/sonnet-5.8.0.tar.xz"
-  sha1 "fd7c2d3bbb87194841569c126cf76223147c656d"
+  url "http://download.kde.org/stable/frameworks/5.9/sonnet-5.9.0.tar.xz"
+  sha1 "e9f52e3dfacb71106110408b4630d5c031afdfd9"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/sonnet.git'

--- a/kf5-threadweaver.rb
+++ b/kf5-threadweaver.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Threadweaver < Formula
-  url "http://download.kde.org/stable/frameworks/5.8/threadweaver-5.8.0.tar.xz"
-  sha1 "83f20747d64cbfa3840132d0e73717bd10cacf99"
+  url "http://download.kde.org/stable/frameworks/5.9/threadweaver-5.9.0.tar.xz"
+  sha1 "dcc9a027d4ddb16513a22dd5ae375ae3e23d485e"
   homepage "http://www.kde.org/"
 
   depends_on "cmake" => :build

--- a/tools/update-formulas.pl
+++ b/tools/update-formulas.pl
@@ -79,10 +79,9 @@ my %frameworks = (
     'kross' => 'portingAids/kross'
 );
 
-my $upstream_url = "http://download.kde.org/stable/frameworks/5.8/";
+my $upstream_url = "http://download.kde.org/stable/frameworks/5.9/";
 
-my $extra_cmake_modules_upstream_suffix = "-1.8.0.tar.xz";
-my $frameworks_upstream_suffix = "-5.8.0.tar.xz";
+my $frameworks_upstream_suffix = "-5.9.0.tar.xz";
 my $brew_prefix = `brew --cache`;
 
 if ($? != 0) {
@@ -96,9 +95,6 @@ sub updatePackage($) {
     my $package = $_[0];
 
     my $upstream_suffix = $frameworks_upstream_suffix;
-    if ($package eq 'extra-cmake-modules') {
-        $upstream_suffix = $extra_cmake_modules_upstream_suffix;
-    }
 
     my $upstream = $frameworks{$package};
     if ($upstream eq '') {


### PR DESCRIPTION
KF5 v5.9.0 was released April 10, 2015. Here's the updated formulas.

Note that:

    Extra CMake Modules (ECM) is now versioned like KDE Frameworks, therefore it is now 5.9, while it was 1.8 previously.

See https://www.kde.org/announcements/kde-frameworks-5.9.0.php
