### PR TITLE
KF5 v5.16.0

### DIFF
--- a/kf5-attica.rb
+++ b/kf5-attica.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Attica < Formula
-  url "http://download.kde.org/stable/frameworks/5.14/attica-5.14.0.tar.xz"
-  sha1 "a438aaacd23afc4aac779effe5ba20cec55e9328"
+  url "http://download.kde.org/stable/frameworks/5.16/attica-5.16.0.tar.xz"
+  sha1 "f91a9827011a7d926c4de1779693281c7b459dbd"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/attica.git'

--- a/kf5-extra-cmake-modules.rb
+++ b/kf5-extra-cmake-modules.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5ExtraCmakeModules < Formula
-  url "http://download.kde.org/stable/frameworks/5.14/extra-cmake-modules-5.14.0.tar.xz"
-  sha1 "6e88ebe4acea14d7b8a0eaadcc3f2892d6a9b304"
+  url "http://download.kde.org/stable/frameworks/5.16/extra-cmake-modules-5.16.0.tar.xz"
+  sha1 "77f1fe2a0faac3bf620dca785a4b50de8870e3a0"
   homepage "http://www.kde.org/"
 
   keg_only "Only required for building KDE frameworks"

--- a/kf5-frameworkintegration.rb
+++ b/kf5-frameworkintegration.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Frameworkintegration < Formula
-  url "http://download.kde.org/stable/frameworks/5.14/frameworkintegration-5.14.0.tar.xz"
-  sha1 "12e3d9f3236cd14745c4ca38da79676d8082f3f6"
+  url "http://download.kde.org/stable/frameworks/5.16/frameworkintegration-5.16.0.tar.xz"
+  sha1 "dd7882de1be546911a74f027ec70e94e390c0f44"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/frameworkintegration.git'

--- a/kf5-kactivities.rb
+++ b/kf5-kactivities.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kactivities < Formula
-  url "http://download.kde.org/stable/frameworks/5.14/kactivities-5.14.0.tar.xz"
-  sha1 "dbc47dc29d7b209c35c662d6e6d967afb5d68340"
+  url "http://download.kde.org/stable/frameworks/5.16/kactivities-5.16.0.tar.xz"
+  sha1 "0bcb9b6fc708144f7a5f444b9d82378f503e72b2"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kactivities.git'

--- a/kf5-kapidox.rb
+++ b/kf5-kapidox.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kapidox < Formula
-  url "http://download.kde.org/stable/frameworks/5.14/kapidox-5.14.0.tar.xz"
-  sha1 "d52d4f6c32a93ed022ef7c318869260595d22bcf"
+  url "http://download.kde.org/stable/frameworks/5.16/kapidox-5.16.0.tar.xz"
+  sha1 "0939d5c404b9bd50cbfe97d05fba7cf93b3877d3"
   homepage "http://www.kde.org/"
 
   depends_on "cmake" => :build

--- a/kf5-karchive.rb
+++ b/kf5-karchive.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Karchive < Formula
-  url "http://download.kde.org/stable/frameworks/5.14/karchive-5.14.0.tar.xz"
-  sha1 "bd637c0677dfa2e8e2e2b9ff8f961e5e615cb341"
+  url "http://download.kde.org/stable/frameworks/5.16/karchive-5.16.0.tar.xz"
+  sha1 "1198a2db75f0b776586fb798da4fd04a71b80229"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/karchive.git'

--- a/kf5-kauth.rb
+++ b/kf5-kauth.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kauth < Formula
-  url "http://download.kde.org/stable/frameworks/5.14/kauth-5.14.0.tar.xz"
-  sha1 "434f9e70793fe3ff38c054adfb308be5397dd693"
+  url "http://download.kde.org/stable/frameworks/5.16/kauth-5.16.0.tar.xz"
+  sha1 "eee85909007a3056e7f8e0bb47f6274a6bae5bbb"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kauth.git'

--- a/kf5-kbookmarks.rb
+++ b/kf5-kbookmarks.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kbookmarks < Formula
-  url "http://download.kde.org/stable/frameworks/5.14/kbookmarks-5.14.0.tar.xz"
-  sha1 "2d9ba4a42cbc745893700a7bb99fa98a4dc58f43"
+  url "http://download.kde.org/stable/frameworks/5.16/kbookmarks-5.16.0.tar.xz"
+  sha1 "761de2a7beb019d7abc0b810b853f5311379e8eb"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kbookmarks.git'

--- a/kf5-kcmutils.rb
+++ b/kf5-kcmutils.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kcmutils < Formula
-  url "http://download.kde.org/stable/frameworks/5.14/kcmutils-5.14.0.tar.xz"
-  sha1 "774adc704eadc75ca5943eda2a674488493930d8"
+  url "http://download.kde.org/stable/frameworks/5.16/kcmutils-5.16.0.tar.xz"
+  sha1 "8bab1bff0304cbc29f841461929dacedce9dc0fa"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kcmutils.git'

--- a/kf5-kcodecs.rb
+++ b/kf5-kcodecs.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kcodecs < Formula
-  url "http://download.kde.org/stable/frameworks/5.14/kcodecs-5.14.0.tar.xz"
-  sha1 "92af550a4f060d62e3355b498f582b5c05760ab5"
+  url "http://download.kde.org/stable/frameworks/5.16/kcodecs-5.16.0.tar.xz"
+  sha1 "ec8b31dee7f43d231b7bf2703be97831cb7bb337"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kcodecs.git'

--- a/kf5-kcompletion.rb
+++ b/kf5-kcompletion.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kcompletion < Formula
-  url "http://download.kde.org/stable/frameworks/5.14/kcompletion-5.14.0.tar.xz"
-  sha1 "99fc184fdd5936afc384b8c0ee744b71a660997e"
+  url "http://download.kde.org/stable/frameworks/5.16/kcompletion-5.16.0.tar.xz"
+  sha1 "d95458558d8bf58090ab08dfe270c16801b4f219"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kcompletion.git'

--- a/kf5-kconfig.rb
+++ b/kf5-kconfig.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kconfig < Formula
-  url "http://download.kde.org/stable/frameworks/5.14/kconfig-5.14.0.tar.xz"
-  sha1 "81e8410f54eb0a508cb00a20b38ed52ffdb737aa"
+  url "http://download.kde.org/stable/frameworks/5.16/kconfig-5.16.0.tar.xz"
+  sha1 "cc86a01c563e727208b330db8f22e8ed03e21c1f"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kconfig.git'

--- a/kf5-kconfigwidgets.rb
+++ b/kf5-kconfigwidgets.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kconfigwidgets < Formula
-  url "http://download.kde.org/stable/frameworks/5.14/kconfigwidgets-5.14.0.tar.xz"
-  sha1 "5a27c44f7677b7de1867981bd0c43c8c50bb94c7"
+  url "http://download.kde.org/stable/frameworks/5.16/kconfigwidgets-5.16.0.tar.xz"
+  sha1 "fff8385b6b65e33bf9c7262a0727e0564a660697"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kconfigwidgets.git'

--- a/kf5-kcoreaddons.rb
+++ b/kf5-kcoreaddons.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kcoreaddons < Formula
-  url "http://download.kde.org/stable/frameworks/5.14/kcoreaddons-5.14.0.tar.xz"
-  sha1 "848e513d39f185eaf8c4bfb65a5b13d6fd1391fc"
+  url "http://download.kde.org/stable/frameworks/5.16/kcoreaddons-5.16.0.tar.xz"
+  sha1 "41abe456bfffe752e5fd3add67ea57a8a69d8176"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kcoreaddons.git'

--- a/kf5-kcrash.rb
+++ b/kf5-kcrash.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kcrash < Formula
-  url "http://download.kde.org/stable/frameworks/5.14/kcrash-5.14.0.tar.xz"
-  sha1 "04403e6b8c0dc4c81fc156f8701e71423da71121"
+  url "http://download.kde.org/stable/frameworks/5.16/kcrash-5.16.0.tar.xz"
+  sha1 "28c3d737c3146e8e61c7de82b5c32e29083da631"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kcrash.git'

--- a/kf5-kdbusaddons.rb
+++ b/kf5-kdbusaddons.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kdbusaddons < Formula
-  url "http://download.kde.org/stable/frameworks/5.14/kdbusaddons-5.14.0.tar.xz"
-  sha1 "679787484dc8c77b6f53897c27bc14d8a3846eb6"
+  url "http://download.kde.org/stable/frameworks/5.16/kdbusaddons-5.16.0.tar.xz"
+  sha1 "f3bb28ed148f99c87121be97876a67be41ad7c3a"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kdbusaddons.git'

--- a/kf5-kdeclarative.rb
+++ b/kf5-kdeclarative.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kdeclarative < Formula
-  url "http://download.kde.org/stable/frameworks/5.14/kdeclarative-5.14.0.tar.xz"
-  sha1 "37ed60ced1b6ceb9a508035f1cac5442ad8cc323"
+  url "http://download.kde.org/stable/frameworks/5.16/kdeclarative-5.16.0.tar.xz"
+  sha1 "5c1843fcf4f3022811a805690b794f9839e1b008"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kdeclarative.git'

--- a/kf5-kded.rb
+++ b/kf5-kded.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kded < Formula
-  url "http://download.kde.org/stable/frameworks/5.14/kded-5.14.0.tar.xz"
-  sha1 "3576ddcd8180817a6d47a839ed565c8dbd0cbf1d"
+  url "http://download.kde.org/stable/frameworks/5.16/kded-5.16.0.tar.xz"
+  sha1 "c67985715a8f27a6e64c5654fa675e84ffaa0e4f"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kded.git'

--- a/kf5-kdelibs4support.rb
+++ b/kf5-kdelibs4support.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kdelibs4support < Formula
-  url "http://download.kde.org/stable/frameworks/5.14/portingAids/kdelibs4support-5.14.0.tar.xz"
-  sha1 "615e96360453a78c43e26fbfb5b52ee44f9e8fc5"
+  url "http://download.kde.org/stable/frameworks/5.16/portingAids/kdelibs4support-5.16.0.tar.xz"
+  sha1 "13c9a91465541ad3f7e915fa732db9740ea15522"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kdelibs4support.git'

--- a/kf5-kdesignerplugin.rb
+++ b/kf5-kdesignerplugin.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kdesignerplugin < Formula
-  url "http://download.kde.org/stable/frameworks/5.14/kdesignerplugin-5.14.0.tar.xz"
-  sha1 "051beaf550169f44058fcf5bf638f41be1728b19"
+  url "http://download.kde.org/stable/frameworks/5.16/kdesignerplugin-5.16.0.tar.xz"
+  sha1 "03a45863096f71133db7b17b8bee755468be5df4"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kdesignerplugin.git'

--- a/kf5-kdesignerplugin.rb
+++ b/kf5-kdesignerplugin.rb
@@ -14,10 +14,6 @@ class Kf5Kdesignerplugin < Formula
   depends_on "haraldf/kf5/kf5-kplotting"
   depends_on "qt5" => "with-d-bus"
 
-  def patches
-    DATA
-  end
-
   def install
     args = std_cmake_args
 
@@ -27,67 +23,3 @@ class Kf5Kdesignerplugin < Formula
     prefix.install "install_manifest.txt"
   end
 end
-
-__END__
-commit 6cbf534c3cd2c5bdda819e092c9778c27e814161
-Author: Kurt Hindenburg <kurt.hindenburg@gmail.com>
-Date:   Wed Sep 16 06:15:52 2015 -0700
-
-    Qt moc can't handle macros (QT_VERSION_CHECK)
-    
-    Fix build by removing macro and using hard-coded version.  Tested with
-    Qt 5.4.x
-    
-    OK per David Faure
-
-diff --git a/src/kgendesignerplugin.cpp b/src/kgendesignerplugin.cpp
-index bc4de47..a2c3869 100644
---- a/src/kgendesignerplugin.cpp
-+++ b/src/kgendesignerplugin.cpp
-@@ -21,7 +21,7 @@ static const char classHeader[] =   "/**\n"
-                                     "*/\n"
-                                     "#include <QIcon>\n"
-                                     "#include <QtDesigner/QDesignerContainerExtension>\n"
--                                    "#if QT_VERSION >= QT_VERSION_CHECK(5, 5, 0)\n"
-+                                    "#if QT_VERSION >= 0x050500\n"
-                                     "# include <QtUiPlugin/QDesignerCustomWidgetInterface>\n"
-                                     "#else\n"
-                                     "# include <QDesignerCustomWidgetInterface>\n"
-commit 8669cfd5f9527f0e8584caf93a758e10102690e1
-Author: Harald Fernengel <harald.fernengel@here.com>
-Date:   Fri Sep 25 14:04:24 2015 +0300
-
-    Fix build on Mac OS X
-
-    Qt 5.5 requires Qt5UiPlugin framework to be in the include path.
-    On Linux this didn't break as all Qt headers are typically in the
-    same prefix, but on Mac, the include hierarchy is quite different.
-
-diff --git a/KF5DesignerPluginMacros.cmake b/KF5DesignerPluginMacros.cmake
-index 15db23d..0dfa9cd 100644
---- a/KF5DesignerPluginMacros.cmake
-+++ b/KF5DesignerPluginMacros.cmake
-@@ -87,9 +87,22 @@ macro(kf5designerplugin_add_plugin target)
-             PURPOSE "Required to build Qt Designer plugins"
-         )
-     endif()
-+    if(NOT Qt5Designer_VERSION_STRING VERSION_LESS 5.5.0 AND NOT Qt5UiPlugin_FOUND)
-+        find_package(Qt5UiPlugin ${REQUIRED_QT_VERSION} ${_requiredarg} NO_MODULE)
-+        set_package_properties(Qt5UiPlugin PROPERTIES
-+            PURPOSE "Required to build Qt Designer plugins"
-+        )
-+    endif()
-+    if (Qt5UiPlugin_FOUND)
-+        # for some reason, Qt5UiPlugin does not set its _INCLUDE_DIRS variable. Fill it manually
-+        get_target_property(Qt5UiPlugin_INCLUDE_DIRS Qt5::UiPlugin INTERFACE_INCLUDE_DIRECTORIES)
-+    endif()
-     if(Qt5Designer_FOUND)
-         add_library(${target} MODULE ${_files})
--        target_include_directories(${target} PRIVATE ${Qt5Designer_INCLUDE_DIRS})
-+        target_include_directories(${target}
-+             PRIVATE ${Qt5UiPlugin_INCLUDE_DIRS}
-+             PRIVATE ${Qt5Designer_INCLUDE_DIRS}
-+        )
-     endif()
- endmacro()
- 

--- a/kf5-kdesu.rb
+++ b/kf5-kdesu.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kdesu < Formula
-  url "http://download.kde.org/stable/frameworks/5.14/kdesu-5.14.0.tar.xz"
-  sha1 "9057b5cb5171bd98eee4cb139a6bd2e800d305b3"
+  url "http://download.kde.org/stable/frameworks/5.16/kdesu-5.16.0.tar.xz"
+  sha1 "09e0c86d921977ad8c2dc2cdf7f3ec81f6a830b7"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kdesu.git'

--- a/kf5-kdewebkit.rb
+++ b/kf5-kdewebkit.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kdewebkit < Formula
-  url "http://download.kde.org/stable/frameworks/5.14/kdewebkit-5.14.0.tar.xz"
-  sha1 "e43596d4ffdef76c5be3f4e439af0039caacd103"
+  url "http://download.kde.org/stable/frameworks/5.16/kdewebkit-5.16.0.tar.xz"
+  sha1 "cb0600fbce2e3a225ac0e4e56d4bc036dad5058f"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/attica.git'

--- a/kf5-kdnssd.rb
+++ b/kf5-kdnssd.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kdnssd < Formula
-  url "http://download.kde.org/stable/frameworks/5.14/kdnssd-5.14.0.tar.xz"
-  sha1 "d6f431e5c05751cde1682c59d5512a180daefc36"
+  url "http://download.kde.org/stable/frameworks/5.16/kdnssd-5.16.0.tar.xz"
+  sha1 "6b7eb7565ee1dbc1ba88bc93ae54bf9afc3286b7"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/attica.git'

--- a/kf5-kdoctools.rb
+++ b/kf5-kdoctools.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kdoctools < Formula
-  url "http://download.kde.org/stable/frameworks/5.14/kdoctools-5.14.0.tar.xz"
-  sha1 "d35c9c91f9e3f9eeb95fc7194f24987e440bd7dc"
+  url "http://download.kde.org/stable/frameworks/5.16/kdoctools-5.16.0.tar.xz"
+  sha1 "519d9ad68b5b81e3c4f3892611e2aa84822e0ef8"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kdoctools.git'

--- a/kf5-kemoticons.rb
+++ b/kf5-kemoticons.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kemoticons < Formula
-  url "http://download.kde.org/stable/frameworks/5.14/kemoticons-5.14.0.tar.xz"
-  sha1 "b45a09db137378c96f5e709e196c9a637f31955d"
+  url "http://download.kde.org/stable/frameworks/5.16/kemoticons-5.16.0.tar.xz"
+  sha1 "f164822e1ff4972f7beb466083c283dc53c56875"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kemoticons.git'

--- a/kf5-kglobalaccel.rb
+++ b/kf5-kglobalaccel.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kglobalaccel < Formula
-  url "http://download.kde.org/stable/frameworks/5.14/kglobalaccel-5.14.0.tar.xz"
-  sha1 "729ec1876559a195ab6e99e1cf24fef439ad8ae2"
+  url "http://download.kde.org/stable/frameworks/5.16/kglobalaccel-5.16.0.tar.xz"
+  sha1 "674481b0bcb9026755269aa63b59e9ec7e2c17de"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kglobalaccel.git'

--- a/kf5-kguiaddons.rb
+++ b/kf5-kguiaddons.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kguiaddons < Formula
-  url "http://download.kde.org/stable/frameworks/5.14/kguiaddons-5.14.0.tar.xz"
-  sha1 "671e74cda0a6980824c212a7eeb89371051cc77e"
+  url "http://download.kde.org/stable/frameworks/5.16/kguiaddons-5.16.0.tar.xz"
+  sha1 "b700b2d0a8bee7e5181ef424256e86a613135583"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kguiaddons.git'

--- a/kf5-ki18n.rb
+++ b/kf5-ki18n.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Ki18n < Formula
-  url "http://download.kde.org/stable/frameworks/5.14/ki18n-5.14.0.tar.xz"
-  sha1 "4d8a9b3b83b6340cb7b6f6dcffe03485ca16d2db"
+  url "http://download.kde.org/stable/frameworks/5.16/ki18n-5.16.0.tar.xz"
+  sha1 "289e9a84159c2bf33a9f90f1ab2b71b1540eb2d3"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/ki18n.git'

--- a/kf5-kiconthemes.rb
+++ b/kf5-kiconthemes.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kiconthemes < Formula
-  url "http://download.kde.org/stable/frameworks/5.14/kiconthemes-5.14.0.tar.xz"
-  sha1 "29731629923eb2a7480833f44af8440f8ac456ec"
+  url "http://download.kde.org/stable/frameworks/5.16/kiconthemes-5.16.0.tar.xz"
+  sha1 "5f8e5d709a6dca841d374ae48e465681eae033f5"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kiconthemes.git'

--- a/kf5-kidletime.rb
+++ b/kf5-kidletime.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kidletime < Formula
-  url "http://download.kde.org/stable/frameworks/5.14/kidletime-5.14.0.tar.xz"
-  sha1 "52ab2c92bca4dfbc80cd3bb2a33777aaf3a1c612"
+  url "http://download.kde.org/stable/frameworks/5.16/kidletime-5.16.0.tar.xz"
+  sha1 "820bbc9c30f8adcfe10481d8c1877e54fe9f8299"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kidletime.git'

--- a/kf5-kimageformats.rb
+++ b/kf5-kimageformats.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kimageformats < Formula
-  url "http://download.kde.org/stable/frameworks/5.14/kimageformats-5.14.0.tar.xz"
-  sha1 "b7345a50c9a453e2e1f5e00ad588b9766a5a18bc"
+  url "http://download.kde.org/stable/frameworks/5.16/kimageformats-5.16.0.tar.xz"
+  sha1 "8db25197f068b8eaf0f99c5657c8dc0cbd4aa87b"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kimageformats.git'

--- a/kf5-kinit.rb
+++ b/kf5-kinit.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kinit < Formula
-  url "http://download.kde.org/stable/frameworks/5.14/kinit-5.14.0.tar.xz"
-  sha1 "af9d6737b8322c1c71e800af4e91cc81ed4456ba"
+  url "http://download.kde.org/stable/frameworks/5.16/kinit-5.16.0.tar.xz"
+  sha1 "1332315cf059a46d3e0e5d7dcc309489ec6e94ee"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kinit.git'

--- a/kf5-kio.rb
+++ b/kf5-kio.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kio < Formula
-  url "http://download.kde.org/stable/frameworks/5.14/kio-5.14.0.tar.xz"
-  sha1 "b13653322bba5a28e1d01199ee3c84b67cadfa79"
+  url "http://download.kde.org/stable/frameworks/5.16/kio-5.16.0.tar.xz"
+  sha1 "7d29772dbceca294de817f96f1611c6602448cae"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kio.git'

--- a/kf5-kitemmodels.rb
+++ b/kf5-kitemmodels.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kitemmodels < Formula
-  url "http://download.kde.org/stable/frameworks/5.14/kitemmodels-5.14.0.tar.xz"
-  sha1 "38f23be0fd9b2a3a220ac39cdc418518c48655af"
+  url "http://download.kde.org/stable/frameworks/5.16/kitemmodels-5.16.0.tar.xz"
+  sha1 "4edb4c51ae48fc7938c74a4fea346cf3c8e84b61"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kitemmodels.git'

--- a/kf5-kitemviews.rb
+++ b/kf5-kitemviews.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kitemviews < Formula
-  url "http://download.kde.org/stable/frameworks/5.14/kitemviews-5.14.0.tar.xz"
-  sha1 "b0f1b2751b7ec7f27b4297d6ffd758403ff7b667"
+  url "http://download.kde.org/stable/frameworks/5.16/kitemviews-5.16.0.tar.xz"
+  sha1 "4a33d254f20d332a3d302d8334306d54e913b2d5"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kitemviews.git'

--- a/kf5-kjobwidgets.rb
+++ b/kf5-kjobwidgets.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kjobwidgets < Formula
-  url "http://download.kde.org/stable/frameworks/5.14/kjobwidgets-5.14.0.tar.xz"
-  sha1 "9e4d67e4453e9e637bf422259dbc88a058e3bed0"
+  url "http://download.kde.org/stable/frameworks/5.16/kjobwidgets-5.16.0.tar.xz"
+  sha1 "66e131e956dc49426c95cffdc147594e076d0b51"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kjobwidgets.git'

--- a/kf5-kjs.rb
+++ b/kf5-kjs.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kjs < Formula
-  url "http://download.kde.org/stable/frameworks/5.14/portingAids/kjs-5.14.0.tar.xz"
-  sha1 "56b9ce4eafbe5f75ae08b732e193a2e507fc2bb3"
+  url "http://download.kde.org/stable/frameworks/5.16/portingAids/kjs-5.16.0.tar.xz"
+  sha1 "2238aabad8813fbc6d8e2d4f19950e23f8ce8de0"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kjs.git'

--- a/kf5-kjsembed.rb
+++ b/kf5-kjsembed.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kjsembed < Formula
-  url "http://download.kde.org/stable/frameworks/5.14/portingAids/kjsembed-5.14.0.tar.xz"
-  sha1 "7564adf5411304c3f32488dc4f275477f2883068"
+  url "http://download.kde.org/stable/frameworks/5.16/portingAids/kjsembed-5.16.0.tar.xz"
+  sha1 "e0d343475a6b3709fd062f54b07c83297f6e3670"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/attica.git'

--- a/kf5-kmediaplayer.rb
+++ b/kf5-kmediaplayer.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kmediaplayer < Formula
-  url "http://download.kde.org/stable/frameworks/5.14/portingAids/kmediaplayer-5.14.0.tar.xz"
-  sha1 "7280350e2aea095a3c5f40f4d87b13cdb86125f4"
+  url "http://download.kde.org/stable/frameworks/5.16/portingAids/kmediaplayer-5.16.0.tar.xz"
+  sha1 "9b8cfb4262fbf8b5be9987782c7c0a36f2537803"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/attica.git'

--- a/kf5-knewstuff.rb
+++ b/kf5-knewstuff.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Knewstuff < Formula
-  url "http://download.kde.org/stable/frameworks/5.14/knewstuff-5.14.0.tar.xz"
-  sha1 "b9b7790a5b49e5f1752023032a61931a1459e772"
+  url "http://download.kde.org/stable/frameworks/5.16/knewstuff-5.16.0.tar.xz"
+  sha1 "ff3a25be8618fa1b80dc46a7df35f6a5ee904199"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/knewstuff.git'

--- a/kf5-knotifications.rb
+++ b/kf5-knotifications.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Knotifications < Formula
-  url "http://download.kde.org/stable/frameworks/5.14/knotifications-5.14.0.tar.xz"
-  sha1 "ce8def2e20747381a820ea7ce7ea50c7e2390efa"
+  url "http://download.kde.org/stable/frameworks/5.16/knotifications-5.16.0.tar.xz"
+  sha1 "5fc93b41eaa9b50066e74fca77806b74b70d9db1"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/knotifications.git'

--- a/kf5-knotifyconfig.rb
+++ b/kf5-knotifyconfig.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Knotifyconfig < Formula
-  url "http://download.kde.org/stable/frameworks/5.14/knotifyconfig-5.14.0.tar.xz"
-  sha1 "28adae56b29f509f03c48bf845588ce760fae82e"
+  url "http://download.kde.org/stable/frameworks/5.16/knotifyconfig-5.16.0.tar.xz"
+  sha1 "dee177085dd79b0ca583f141433a3eff681040d9"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/knotifyconfig.git'

--- a/kf5-kpackage.rb
+++ b/kf5-kpackage.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kpackage < Formula
-  url "http://download.kde.org/stable/frameworks/5.14/kpackage-5.14.0.tar.xz"
-  sha1 "e93d2a29b68d66138816e234fbb8fcbd45e5f982"
+  url "http://download.kde.org/stable/frameworks/5.16/kpackage-5.16.0.tar.xz"
+  sha1 "946575a1fb83bef5580e8accf37c0d7967159b9f"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kpackage.git'

--- a/kf5-kparts.rb
+++ b/kf5-kparts.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kparts < Formula
-  url "http://download.kde.org/stable/frameworks/5.14/kparts-5.14.0.tar.xz"
-  sha1 "cbd5fb7579c43f704ed28d3925a4a391c52926c8"
+  url "http://download.kde.org/stable/frameworks/5.16/kparts-5.16.0.tar.xz"
+  sha1 "1cc7901e49222936940de1b3dd00ef1a2ca2bdbd"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kparts.git'

--- a/kf5-kplotting.rb
+++ b/kf5-kplotting.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kplotting < Formula
-  url "http://download.kde.org/stable/frameworks/5.14/kplotting-5.14.0.tar.xz"
-  sha1 "a2d6b3e662b0db3eab6db3750f27cfdbb5bff964"
+  url "http://download.kde.org/stable/frameworks/5.16/kplotting-5.16.0.tar.xz"
+  sha1 "2a78958cc598d1b527c9bf53e7e096712db82e92"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kplotting.git'

--- a/kf5-kpty.rb
+++ b/kf5-kpty.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kpty < Formula
-  url "http://download.kde.org/stable/frameworks/5.14/kpty-5.14.0.tar.xz"
-  sha1 "c235525f4ebe4bc2a082d95f515f362de8760b6c"
+  url "http://download.kde.org/stable/frameworks/5.16/kpty-5.16.0.tar.xz"
+  sha1 "e7a2d59a0c63a1f7f25e3e8fa61d9f7f3da2ff31"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kpty.git'

--- a/kf5-kross.rb
+++ b/kf5-kross.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kross < Formula
-  url "http://download.kde.org/stable/frameworks/5.14/portingAids/kross-5.14.0.tar.xz"
-  sha1 "9b9c8b84df50529936ce1678aa2d1d93f3bf3f46"
+  url "http://download.kde.org/stable/frameworks/5.16/portingAids/kross-5.16.0.tar.xz"
+  sha1 "5880f623d15d736bdcba144aba9d84da6c643aab"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kross.git'

--- a/kf5-kservice.rb
+++ b/kf5-kservice.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kservice < Formula
-  url "http://download.kde.org/stable/frameworks/5.14/kservice-5.14.0.tar.xz"
-  sha1 "3ff46cd246369e3d050ac2c973c070eaf0917892"
+  url "http://download.kde.org/stable/frameworks/5.16/kservice-5.16.0.tar.xz"
+  sha1 "a0b38c87a20ec23d58ed309444072ed2439e7aa9"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kservice.git'

--- a/kf5-ktexteditor.rb
+++ b/kf5-ktexteditor.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Ktexteditor < Formula
-  url "http://download.kde.org/stable/frameworks/5.14/ktexteditor-5.14.0.tar.xz"
-  sha1 "e971bf1274a59079f2deb8aa83b40aaf54bbe37f"
+  url "http://download.kde.org/stable/frameworks/5.16/ktexteditor-5.16.0.tar.xz"
+  sha1 "a06d0da51efbf30506fa5307069c9527641df614"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/ktexteditor.git'

--- a/kf5-ktextwidgets.rb
+++ b/kf5-ktextwidgets.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Ktextwidgets < Formula
-  url "http://download.kde.org/stable/frameworks/5.14/ktextwidgets-5.14.0.tar.xz"
-  sha1 "c6cf51b1b69c2c3973d85fdf745be479588dc96c"
+  url "http://download.kde.org/stable/frameworks/5.16/ktextwidgets-5.16.0.tar.xz"
+  sha1 "ac0cfa11e4da8b5dc0019019ca7844d448cc4e84"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/ktextwidgets.git'

--- a/kf5-kunitconversion.rb
+++ b/kf5-kunitconversion.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kunitconversion < Formula
-  url "http://download.kde.org/stable/frameworks/5.14/kunitconversion-5.14.0.tar.xz"
-  sha1 "b9890a2d76dc5262e28d3ffe8328eb013142017b"
+  url "http://download.kde.org/stable/frameworks/5.16/kunitconversion-5.16.0.tar.xz"
+  sha1 "a26f7e960e5ffdc3fdc885c3af457ac3e490ac54"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kunitconversion.git'

--- a/kf5-kwallet.rb
+++ b/kf5-kwallet.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kwallet < Formula
-  url "http://download.kde.org/stable/frameworks/5.14/kwallet-5.14.0.tar.xz"
-  sha1 "35a82a378dc78bde2b66ffb631e6d732089b4786"
+  url "http://download.kde.org/stable/frameworks/5.16/kwallet-5.16.0.tar.xz"
+  sha1 "3d337d88b54296f73a92466425cefd381bc9f6de"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kwallet.git'

--- a/kf5-kwidgetsaddons.rb
+++ b/kf5-kwidgetsaddons.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kwidgetsaddons < Formula
-  url "http://download.kde.org/stable/frameworks/5.14/kwidgetsaddons-5.14.0.tar.xz"
-  sha1 "196a2b081c0a498e7e9df54ba78c833349b8f006"
+  url "http://download.kde.org/stable/frameworks/5.16/kwidgetsaddons-5.16.0.tar.xz"
+  sha1 "67f0186ee31903869ff1800fbe778fe8c87bb53f"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kwidgetsaddons.git'

--- a/kf5-kwindowsystem.rb
+++ b/kf5-kwindowsystem.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kwindowsystem < Formula
-  url "http://download.kde.org/stable/frameworks/5.14/kwindowsystem-5.14.0.tar.xz"
-  sha1 "0b3e1f102d14211ad6b0a5cb0533842d346c09a1"
+  url "http://download.kde.org/stable/frameworks/5.16/kwindowsystem-5.16.0.tar.xz"
+  sha1 "211ba6a5cecd2c49cebf75bf46256e0e3065e662"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kwindowsystem.git'

--- a/kf5-kxmlgui.rb
+++ b/kf5-kxmlgui.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Kxmlgui < Formula
-  url "http://download.kde.org/stable/frameworks/5.14/kxmlgui-5.14.0.tar.xz"
-  sha1 "0eca5ff26a4b46f39d9c07a41df9320758a1ce39"
+  url "http://download.kde.org/stable/frameworks/5.16/kxmlgui-5.16.0.tar.xz"
+  sha1 "1b1a8d85ef6519c34d5e7242384ff25aa540c48b"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/kxmlgui.git'

--- a/kf5-solid.rb
+++ b/kf5-solid.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Solid < Formula
-  url "http://download.kde.org/stable/frameworks/5.14/solid-5.14.0.tar.xz"
-  sha1 "192ec7e4668d3a39c967652d5ced954c567e8bad"
+  url "http://download.kde.org/stable/frameworks/5.16/solid-5.16.0.tar.xz"
+  sha1 "74be81a3069e228039be35c7e3ab0c54799eb665"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/solid.git'

--- a/kf5-sonnet.rb
+++ b/kf5-sonnet.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Sonnet < Formula
-  url "http://download.kde.org/stable/frameworks/5.14/sonnet-5.14.0.tar.xz"
-  sha1 "44b82628f4765bdc20773576012b23f548a72567"
+  url "http://download.kde.org/stable/frameworks/5.16/sonnet-5.16.0.tar.xz"
+  sha1 "0e015f7b1eefded02ba853a2d93ac1fdc9a5fd7b"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/sonnet.git'

--- a/kf5-threadweaver.rb
+++ b/kf5-threadweaver.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Kf5Threadweaver < Formula
-  url "http://download.kde.org/stable/frameworks/5.14/threadweaver-5.14.0.tar.xz"
-  sha1 "459a2127fab0de8d954c343a60473c83cabb4c0b"
+  url "http://download.kde.org/stable/frameworks/5.16/threadweaver-5.16.0.tar.xz"
+  sha1 "e804841a7cc1c7a8e25597d28bc8ed8fa6c15983"
   homepage "http://www.kde.org/"
 
   depends_on "cmake" => :build

--- a/tools/update-formulas.pl
+++ b/tools/update-formulas.pl
@@ -79,9 +79,9 @@ my %frameworks = (
     'kross' => 'portingAids/kross'
 );
 
-my $upstream_url = "http://download.kde.org/stable/frameworks/5.14/";
+my $upstream_url = "http://download.kde.org/stable/frameworks/5.16/";
 
-my $frameworks_upstream_suffix = "-5.14.0.tar.xz";
+my $frameworks_upstream_suffix = "-5.16.0.tar.xz";
 my $brew_prefix = `brew --cache`;
 
 if ($? != 0) {


### PR DESCRIPTION
Update receipes to v5.16.0.

Note that kf5-kdelibs4support fails to compile, which is a dependency for dolphin. Here's the error:

```
[ 52%] Building CXX object src/CMakeFiles/KF5KDELibs4Support.dir/kio/kfileshare.cpp.o
cd /tmp/kf5-kdelibs4support20151114-37395-17vqsbw/kdelibs4support-5.16.0/src && /usr/local/Library/ENV/4.3/clang++   -DKCOREADDONS_LIB -DKDELIBS4SUPPORT_DEPRECATED="" -DKDELIBS4SUPPORT_DEPRECATED_EXPORT=KDELIBS4SUPPORT_EXPORT -DKDELIBS4SUPPORT_DEPRECATED_NO_EXPORT=KDELIBS4SUPPORT_NO_EXPORT -DKF5KDELibs4Support_EXPORTS -DKGUIADDONS_LIB -DQT_CORE_LIB -DQT_DBUS_LIB -DQT_DISABLE_DEPRECATED_BEFORE=0 -DQT_GUI_LIB -DQT_MAC_USE_COCOA -DQT_NETWORK_LIB -DQT_NO_CAST_TO_ASCII -DQT_NO_DEBUG -DQT_NO_SIGNALS_SLOTS_KEYWORDS -DQT_NO_URL_CAST_FROM_STRING -DQT_PRINTSUPPORT_LIB -DQT_SVG_LIB -DQT_TESTLIB_LIB -DQT_USE_FAST_OPERATOR_PLUS -DQT_WIDGETS_LIB -DQT_XML_LIB -DTRANSLATION_DOMAIN=\"kdelibs4support\" -D_DARWIN_C_SOURCE -D_LARGEFILE64_SOURCE -I/tmp/kf5-kdelibs4support20151114-37395-17vqsbw/kdelibs4support-5.16.0/src -I/tmp/kf5-kdelibs4support20151114-37395-17vqsbw/kdelibs4support-5.16.0/src/../../.. -I/tmp/kf5-kdelibs4support20151114-37395-17vqsbw/kdelibs4support-5.16.0/src/kdecore -I/tmp/kf5-kdelibs4support20151114-37395-17vqsbw/kdelibs4support-5.16.0/src/kdeui -I/tmp/kf5-kdelibs4support20151114-37395-17vqsbw/kdelibs4support-5.16.0/src/kio -I/tmp/kf5-kdelibs4support20151114-37395-17vqsbw/kdelibs4support-5.16.0/src/kssl -I/tmp/kf5-kdelibs4support20151114-37395-17vqsbw/kdelibs4support-5.16.0/src/kparts -I/tmp/kf5-kdelibs4support20151114-37395-17vqsbw/kdelibs4support-5.16.0/src/solid -I/tmp/kf5-kdelibs4support20151114-37395-17vqsbw/kdelibs4support-5.16.0/src/.. -I/tmp/kf5-kdelibs4support20151114-37395-17vqsbw/kdelibs4support-5.16.0 -iframework /usr/local/opt/qt5/lib -isystem /usr/local/opt/qt5/lib/QtWidgets.framework/Headers -isystem /usr/local/opt/qt5/lib/QtGui.framework/Headers -isystem /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk/System/Library/Frameworks/OpenGL.framework/Versions/Current/Headers -isystem /usr/local/opt/qt5/lib/QtCore.framework/Headers -isystem /usr/local/opt/qt5/./mkspecs/macx-clang -isystem /usr/local/opt/qt5/lib/QtDBus.framework/Headers -isystem /usr/local/opt/qt5/lib/QtPrintSupport.framework/Headers -isystem /usr/local/include/KF5/KCoreAddons -isystem /usr/local/include/KF5 -isystem /usr/local/include/KF5/KCrash -isystem /usr/local/include/KF5/KWidgetsAddons -isystem /usr/local/include/KF5/KConfigCore -isystem /usr/local/include/KF5/KConfigWidgets -isystem /usr/local/include/KF5/KCodecs -isystem /usr/local/include/KF5/KConfigGui -isystem /usr/local/opt/qt5/lib/QtXml.framework/Headers -isystem /usr/local/include/KF5/KAuth -isystem /usr/local/include/KF5/KIOCore -isystem /usr/local/include/KF5/KService -isystem /usr/local/include/KF5/KIOFileWidgets -isystem /usr/local/include/KF5/KIOWidgets -isystem /usr/local/include/KF5/KJobWidgets -isystem /usr/local/opt/qt5/lib/QtNetwork.framework/Headers -isystem /usr/local/include/KF5/KCompletion -isystem /usr/local/include/KF5/KBookmarks -isystem /usr/local/include/KF5/KItemViews -isystem /usr/local/include/KF5/KXmlGui -isystem /usr/local/include/KF5/Solid -isystem /usr/local/include/KF5/KI18n -isystem /usr/local/include/KF5/KNotifications -isystem /usr/local/include/KF5/KIconThemes -isystem /usr/local/include/KF5/KWindowSystem -isystem /usr/local/Cellar/kf5-kwindowsystem/5.16.0/include/KF5 -isystem /usr/local/include/KF5/KGuiAddons -isystem /usr/local/include/KF5/KUnitConversion -isystem /usr/local/include/KF5/KTextWidgets -isystem /usr/local/include/KF5/SonnetUi -isystem /usr/local/include/KF5/KParts -isystem /usr/local/include/KF5/KGlobalAccel -isystem /usr/local/opt/qt5/lib/QtSvg.framework/Headers -isystem /usr/local/opt/qt5/lib/QtTest.framework/Headers  -D_DARWIN_C_SOURCE -std=c++0x -fno-exceptions -Wall -Wextra -Wcast-align -Wchar-subscripts -Wformat-security -Wno-long-long -Wpointer-arith -Wundef -Wnon-virtual-dtor -Woverloaded-virtual -Werror=return-type -pedantic -Wno-gnu-zero-variadic-macro-arguments -fvisibility=hidden -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk -fPIC -fvisibility=hidden -fvisibility-inlines-hidden   -fPIC -o CMakeFiles/KF5KDELibs4Support.dir/kio/kfileshare.cpp.o -c /tmp/kf5-kdelibs4support20151114-37395-17vqsbw/kdelibs4support-5.16.0/src/kio/kfileshare.cpp
/tmp/kf5-kdelibs4support20151114-37395-17vqsbw/kdelibs4support-5.16.0/src/kssl/ksslcertificate.cpp:1023:25: error: no member named 'X509_cmp' in 'KOpenSSLProxy'
    if (!KOSSL::self()->X509_cmp(x.getCert(), y.getCert())) {
         ~~~~~~~~~~~~~  ^
1 error generated.
make[2]: *** [src/CMakeFiles/KF5KDELibs4Support.dir/kssl/ksslcertificate.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [src/CMakeFiles/KF5KDELibs4Support.dir/all] Error 2
make: *** [all] Error 2

READ THIS: https://git.io/brew-troubleshooting
If reporting this issue please do so at (not Homebrew/homebrew):
  https://github.com/haraldf/homebrew-kf5/issues
```