### PR TITLE
update Kate formula

### DIFF
--- a/kf5-kate.rb
+++ b/kf5-kate.rb
@@ -1,9 +1,8 @@
-require "formula"
-
 class Kf5Kate < Formula
-  url "http://download.kde.org/stable/applications/15.08.1/src/kate-15.08.1.tar.xz"
-  sha256 "3f96756f7f4c6d178d2310a9fd1b63e816348d49cb4d53907e10fc6a29c92b43"
-  homepage "http://www.kde.org/"
+  desc "Advanced KDE Text Editor"
+  homepage "http://kate-editor.org"
+  url "http://download.kde.org/stable/applications/15.12.2/src/kate-15.12.2.tar.xz"
+  sha256 "071b4fc36e052204379ae9b4670e458dbbccffde9564db8383347ab6e643e4b2"
 
   head "git://anongit.kde.org/kate.git"
 
@@ -28,10 +27,6 @@ class Kf5Kate < Formula
   depends_on "haraldf/kf5/kf5-knewstuff"
   depends_on "haraldf/kf5/kf5-kwallet"
 
-  def patches
-    DATA
-  end
-
   def install
     args = std_cmake_args
 
@@ -41,18 +36,8 @@ class Kf5Kate < Formula
     system "make", "install"
     prefix.install "install_manifest.txt"
   end
-end
 
-__END__
-diff --git a/CMakeLists.txt b/CMakeLists.txt
-index e8f47ed..8de15f1 100644
---- a/CMakeLists.txt
-+++ b/CMakeLists.txt
-@@ -38,6 +38,7 @@ find_package(KF5 REQUIRED COMPONENTS
-   DocTools
-   GuiAddons
-   I18n
-+  IconThemes
-   Init
-   JobWidgets
-   KIO
+  test do
+    assert `/Applications/KDE/kate.app/Contents/MacOS/kate --help | grep -- --help` =~ /--help/
+  end
+end


### PR DESCRIPTION
Point to newest tarball for stable, remove patch as it is no longer
necessary.

Change homepage to Kate homepage and add a desc field.

Add a 'test do' block with a simple test.

brew audit --strict --online passes.

TODO: apps should be installed to Cellar and tell user to brew linkapps
instead of installing things to /Applications directly.