### PR TITLE
konversation does not depend on kf5-kdelibs4support

### DIFF
--- a/kf5-konversation.rb
+++ b/kf5-konversation.rb
@@ -21,7 +21,6 @@ class Kf5Konversation < Formula
   depends_on "haraldf/kf5/kf5-ki18n"
   depends_on "haraldf/kf5/kf5-kidletime"
   depends_on "haraldf/kf5/kf5-knotifyconfig"
-  depends_on "haraldf/kf5/kf5-kdelibs4support"
   depends_on "haraldf/kf5/kf5-kio"
   depends_on "haraldf/kf5/kf5-kparts"
   depends_on "haraldf/kf5/kf5-solid"


### PR DESCRIPTION
I mean the lastest code from git HEAD.

And I tried konversation 1.6.2 and failed to compile it because there are bugs in source code. It miss the "#include <cstdio>" in `viewcontainer.cpp`. I do not know how to patch it using homebrew, so I didn't upgrade konversation to 1.6.2.