### PR TITLE
libkomparediff2 - set correct url

### DIFF
--- a/libkomparediff2.rb
+++ b/libkomparediff2.rb
@@ -1,8 +1,8 @@
 require "formula"
 
 class Libkomparediff2 < Formula
-  url "http://download.kde.org/stable/applications/15.12.3/src/libkomparediff2-15.12.3.tar.xz"
-  sha256 "7602643436f4a3fec003c2468d77b3b8590cf3d32c535d85805a469b490686c7"
+  url "http://download.kde.org/stable/applications/16.12.3/src/libkomparediff2-16.12.3.tar.xz"
+  sha256 "31d14264f37522b2d5472874642cab73fe71ca8e077a6f0dd69de3138469a2c2"
   homepage "http://www.kde.org/"
 
   head 'git://anongit.kde.org/libkomparediff2.git'


### PR DESCRIPTION
Issue:
https://github.com/haraldF/homebrew-kf5/issues/75
https://github.com/haraldF/homebrew-kf5/issues/83